### PR TITLE
fix: fixes async calls

### DIFF
--- a/custom_components/ryobi_gdo/cover.py
+++ b/custom_components/ryobi_gdo/cover.py
@@ -81,12 +81,12 @@ class RyobiCover(CoordinatorEntity, CoverEntity):
         """Flag supported features."""
         return SUPPORTED_FEATURES
 
-    async def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Close the cover."""
         LOGGER.debug("Closing garage door")
         await self.coordinator.close_device()
 
-    async def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Open the cover."""
         LOGGER.debug("Opening garage door")
         await self.coordinator.open_device()

--- a/custom_components/ryobi_gdo/switch.py
+++ b/custom_components/ryobi_gdo/switch.py
@@ -24,9 +24,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class RyobiSwitch(CoordinatorEntity, SwitchEntity):
     """Representation of a ryobi switch."""
 
-    def __init__(
-        self, hass, config_entry: ConfigEntry, coordinator: str
-    ):
+    def __init__(self, hass, config_entry: ConfigEntry, coordinator: str):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device_id = config_entry.data[CONF_DEVICE_ID]

--- a/custom_components/ryobi_gdo/switch.py
+++ b/custom_components/ryobi_gdo/switch.py
@@ -56,12 +56,12 @@ class RyobiSwitch(CoordinatorEntity, SwitchEntity):
             return True
         return False
 
-    async def turn_off(self, **kwargs: Any):
+    async def async_turn_off(self, **kwargs: Any):
         """Turn off light."""
         LOGGER.debug("Turning off light")
         self.coordinator.send_message("lightState", False)
 
-    async def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn on light."""
         LOGGER.debug("Turning on light")
         self.coordinator.send_message("lightState", True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes async calls for light switch and cover.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
