### PR TITLE
fix: make sure websocket is listening before going ready

### DIFF
--- a/custom_components/ryobi_gdo/__init__.py
+++ b/custom_components/ryobi_gdo/__init__.py
@@ -34,8 +34,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
+    # Start websocket listener
+    coordinator._client.ws_connect()
 
-    if not coordinator.last_update_success:
+    if not coordinator.last_update_success or not coordinator._client._ws_listening:
         raise ConfigEntryNotReady
 
     hass.data[DOMAIN][config_entry.entry_id] = {COORDINATOR: coordinator}
@@ -44,9 +46,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
-
-    # Start websocket listener
-    coordinator._client.ws_connect()
 
     return True
 

--- a/custom_components/ryobi_gdo/__init__.py
+++ b/custom_components/ryobi_gdo/__init__.py
@@ -37,7 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Start websocket listener
     coordinator._client.ws_connect()
 
-    if not coordinator.last_update_success or not coordinator._client._ws_listening:
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady
+    if not coordinator._client._ws_listening:
         raise ConfigEntryNotReady
 
     hass.data[DOMAIN][config_entry.entry_id] = {COORDINATOR: coordinator}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Makes sure websockets are listening before continuing setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
