### PR TITLE
fix: use module_types correctly when commanding addon modules

### DIFF
--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -581,8 +581,8 @@ class RyobiWebSocket:
             "method": "gdoModuleCommand",
             "params": {
                 "msgType": 16,
-                "moduleType": args[1],
-                "portId": args[0],
+                "moduleType": int(args[1]),
+                "portId": int(args[0]),
                 "moduleMsg": {args[2]: args[3]},
                 "topic": self._device_id,
             },

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -567,7 +567,7 @@ class RyobiWebSocket:
         except Exception as err:
             LOGGER.error("Websocket error sending message: %s", err)
         return False
-    
+
     def redact_api_key(message: dict) -> dict:
         """Clear API key data from logs."""
         if "params" in message:

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -558,7 +558,7 @@ class RyobiWebSocket:
     async def websocket_send(self, message: dict) -> bool:
         """Send websocket message."""
         json_message = json.dumps(message)
-        LOGGER.debug("Websocket sending data: %s", json_message)
+        LOGGER.debug("Websocket sending data: %s", self.redact_api_key(json_message))
 
         try:
             await self._ws_client.send_str(json_message)
@@ -567,6 +567,13 @@ class RyobiWebSocket:
         except Exception as err:
             LOGGER.error("Websocket error sending message: %s", err)
         return False
+    
+    def redact_api_key(message: dict) -> dict:
+        """Clear API key data from logs."""
+        if "params" in message:
+            if "apiKey" in message["params"]:
+                message["params"]["apiKey"] = ""
+        return message
 
     async def send_message(self, *args):
         """Send message to API."""

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -588,10 +588,11 @@ class RyobiWebSocket:
             },
         }
         LOGGER.debug(
-            "Sending command: %s value: %s portId: %s",
-            args[1],
+            "Sending command: %s value: %s portId: %s moduleType: %s",
             args[2],
+            args[3],
             args[0],
+            args[1],
         )
         LOGGER.debug("Full message: %s", ws_command)
         await self.websocket_send(ws_command)

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -254,6 +254,19 @@ class RyobiApiClient:
         """Return module number for device."""
         return self._modules[module].split("_")[1]
 
+    def get_module_type(self, module: str) -> int:
+        """Return module type for device."""
+        module_type = {
+            "garageDoor": 5,
+            "backupCharger": 6,
+            "garageLight": 5,
+            "wifiModule": 7,
+            "parkAssistLaser": 1,
+            "inflator": 4,
+            "btSpeaker": 2,
+        }
+        return module_type[module]
+
     def ws_connect(self) -> None:
         """Connect to websocket."""
         if self.api_key is None:
@@ -568,9 +581,9 @@ class RyobiWebSocket:
             "method": "gdoModuleCommand",
             "params": {
                 "msgType": 16,
-                "moduleType": 5,
+                "moduleType": args[1],
                 "portId": args[0],
-                "moduleMsg": {args[1]: args[2]},
+                "moduleMsg": {args[2]: args[3]},
                 "topic": self._device_id,
             },
         }

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -47,7 +47,8 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
     async def send_command(self, device: str, command: str, value: bool):
         """Send command to GDO."""
         module = self.client.get_module(device)
-        data = (module, command, value)
+        module_type = self.client.get_module_type(device)
+        data = (module, module_type, command, value)
         await self.client.ws.send_message(*data)
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use proper module_types when commanding addon modules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
