### PR TITLE
fix: poll switch for update after sending command

### DIFF
--- a/custom_components/ryobi_gdo/switch.py
+++ b/custom_components/ryobi_gdo/switch.py
@@ -89,8 +89,8 @@ class RyobiSwitch(CoordinatorEntity, SwitchEntity):
             await self.coordinator.send_command("garageLight", "lightState", False)
         elif self._type == "inflator":
             LOGGER.debug("Turning off inflator")
-            self.coordinator.data["inflator"] = False
             await self.coordinator.send_command("inflator", "moduleState", False)
+            await self.coordinator._async_update_data()
 
     async def async_turn_on(self, **kwargs: dict[str, Any]):
         """Turn on light."""
@@ -99,8 +99,8 @@ class RyobiSwitch(CoordinatorEntity, SwitchEntity):
             await self.coordinator.send_command("garageLight", "lightState", True)
         elif self._type == "inflator":
             LOGGER.debug("Turning on inflator")
-            self.coordinator.data["inflator"] = True
             await self.coordinator.send_command("inflator", "moduleState", True)
+            await self.coordinator._async_update_data()
 
     @property
     def extra_state_attributes(self) -> dict | None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Polls for update after the inflator switch is toggled for a status update

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
