### PR TITLE
fix: add reconnect logic for websocket

### DIFF
--- a/custom_components/ryobi_gdo/__init__.py
+++ b/custom_components/ryobi_gdo/__init__.py
@@ -1,4 +1,5 @@
 """Ryobi component."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -317,6 +317,7 @@ class RyobiApiClient:
         self, msg_type: str, msg: dict, error: str | None = None
     ) -> None:
         """Process websocket data and handle websocket signaling."""
+        LOGGER.debug("Websocket callback msg_type: %s msg: %s err: %s", msg_type, msg, error)
         if msg_type == SIGNAL_CONNECTION_STATE:
             if msg == STATE_CONNECTED:
                 LOGGER.debug("Websocket to %s successful", self.ws.url)

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -317,7 +317,9 @@ class RyobiApiClient:
         self, msg_type: str, msg: dict, error: str | None = None
     ) -> None:
         """Process websocket data and handle websocket signaling."""
-        LOGGER.debug("Websocket callback msg_type: %s msg: %s err: %s", msg_type, msg, error)
+        LOGGER.debug(
+            "Websocket callback msg_type: %s msg: %s err: %s", msg_type, msg, error
+        )
         if msg_type == SIGNAL_CONNECTION_STATE:
             if msg == STATE_CONNECTED:
                 LOGGER.debug("Websocket to %s successful", self.ws.url)

--- a/custom_components/ryobi_gdo/binary_sensor.py
+++ b/custom_components/ryobi_gdo/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for Ryobi GDO."""
+
 import logging
 from typing import Final, cast
 

--- a/custom_components/ryobi_gdo/config_flow.py
+++ b/custom_components/ryobi_gdo/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for Ryobi GDO."""
+
 from __future__ import annotations
 
 import voluptuous as vol

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -57,7 +57,7 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
         """Trigger processing updated websocket data."""
         LOGGER.debug("Processing websocket data.")
         # Websocket dropped out handle reconnecting
-        if self.client.ws_listening == False:
+        if not self.client.ws_listening:
             # Close any left over sessions
             await self.client.ws_disconnect()
             # Reconnect the websocket

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -55,6 +55,12 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
     async def websocket_update(self):
         """Trigger processing updated websocket data."""
         LOGGER.debug("Processing websocket data.")
+        # Websocket dropped out handle reconnecting
+        if self.client.ws_listening == False:
+            # Close any left over sessions
+            await self.client.ws_disconnect()
+            # Reconnect the websocket
+            await self.client.ws_connect()
         self._data = self.client._data
         coordinator = self.hass.data[DOMAIN][self.config.entry_id][COORDINATOR]
         coordinator.async_set_updated_data(self._data)

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinator for ryobi_gdo."""
+
 from __future__ import annotations
 
 from datetime import timedelta


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Have the coordinator reconnect to the websocket if the websocket connection disconnects.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
