### PR TITLE
fix: check websocket before trying to send commands

### DIFF
--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -60,6 +60,7 @@ class RyobiApiClient:
         "1": STATE_OPEN,
         "2": STATE_CLOSING,
         "3": STATE_OPENING,
+        "4": "fault",
     }
 
     def __init__(self, username: str, password: str, device_id: str | None = None):

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -52,7 +52,7 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
             # Close any left over sessions
             await self.client.ws_disconnect()
             # Reconnect the websocket
-            await self.client.ws_connect()        
+            await self.client.ws_connect()
         module = self.client.get_module(device)
         module_type = self.client.get_module_type(device)
         data = (module, module_type, command, value)

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -47,6 +47,12 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def send_command(self, device: str, command: str, value: bool):
         """Send command to GDO."""
+        # Websocket dropped out handle reconnecting
+        if not self.client.ws_listening:
+            # Close any left over sessions
+            await self.client.ws_disconnect()
+            # Reconnect the websocket
+            await self.client.ws_connect()        
         module = self.client.get_module(device)
         module_type = self.client.get_module_type(device)
         data = (module, module_type, command, value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Check the websocket before attempting to send websocket commands

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
