### PR TITLE
fix: set websocket state when error sending

### DIFF
--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -610,6 +610,8 @@ class RyobiWebSocket:
             return True
         except Exception as err:
             LOGGER.error("Websocket error sending message: %s", err)
+            self._error_reason = err
+            await RyobiWebSocket.state.fset(self, STATE_DISCONNECTED)            
         return False
 
     def redact_api_key(self, message: dict) -> dict:

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -611,7 +611,7 @@ class RyobiWebSocket:
         except Exception as err:
             LOGGER.error("Websocket error sending message: %s", err)
             self._error_reason = err
-            await RyobiWebSocket.state.fset(self, STATE_DISCONNECTED)            
+            await RyobiWebSocket.state.fset(self, STATE_DISCONNECTED)
         return False
 
     def redact_api_key(self, message: dict) -> dict:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set websocket flag if error occurs when sending commands on websocket.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
