### PR TITLE
feat(fan): add multi-speed fan platform and per-instance addressing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Check out the **[Ryobi GDO Local Server Add-on](https://github.com/catduckgnaf/r
 | `binary_sensor` | **Park Assist Laser** | Laser module status |
 | `binary_sensor` | **Bluetooth Speaker** | Bluetooth speaker connection |
 | `binary_sensor` | **Server Connection** | Cloud WebSocket link health |
+| `fan` | **Fan / Fan 2** | Fan on/off and three-step speed control |
 | `switch` | **Inflator** | Air compressor module control |
 
 ---

--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -95,6 +95,7 @@ class RyobiApiClient:
         self.ws_listening = False
         self._ws_listen_task: asyncio.Task | None = None
         self._modules: dict[str, str] = {}
+        self._module_instances: dict[str, list[str]] = {}
         self.session = session
 
     @property
@@ -106,6 +107,14 @@ class RyobiApiClient:
     def modules(self) -> dict[str, str]:
         """Return the active device modules."""
         return self._modules
+
+    def module_instances(self, module: str) -> list[str]:
+        """Return every dtm key for a module type, in stable order."""
+        if self._module_instances.get(module):
+            return self._module_instances[module]
+        if module in self._modules:
+            return [self._modules[module]]
+        return []
 
     @property
     def http_scheme(self) -> str:
@@ -303,14 +312,21 @@ class RyobiApiClient:
             if "micEnable" in speaker_at:
                 self._data["micStatus"] = speaker_at["micEnable"].get("value")
 
-        if "fan" in self._modules:
-            fan_at = dtm.get(self._modules["fan"], {}).get("at", {})
-            if "speed" in fan_at:
-                self._data["fan_speed"] = fan_at["speed"].get("value", 0)
-            if "moduleState" in fan_at:
-                self._data["fan"] = fan_at["moduleState"].get("value", 0)
-            elif "speed" in fan_at:
-                self._data["fan"] = 1 if self._data.get("fan_speed", 0) > 0 else 0
+        for idx, fan_key in enumerate(self.module_instances("fan")):
+            fan_at = dtm.get(fan_key, {}).get("at", {})
+            speed = fan_at.get("speed", {}).get("value")
+            state = fan_at.get("moduleState", {}).get("value")
+            if speed is None and state is None:
+                continue
+            if speed is not None:
+                self._data[f"fan_speed_{idx}"] = speed
+            self._data[f"fan_{idx}"] = (
+                state if state is not None else (1 if (speed or 0) > 0 else 0)
+            )
+            if idx == 0:
+                # Back-compat keys for the existing diagnostic sensor.
+                self._data["fan_speed"] = self._data.get("fan_speed_0", 0)
+                self._data["fan"] = self._data["fan_0"]
 
         if "camera" in self._modules or "securityCamera" in self._modules:
             cam_key = self._modules.get("camera") or self._modules.get("securityCamera")
@@ -395,32 +411,49 @@ class RyobiApiClient:
             "securityCamera",
             "extCord",
         ]
-        frame = {}
+        frame: dict[str, str] = {}
+        instances: dict[str, list[str]] = {}
         try:
             for key, val in dtm.items():
                 if isinstance(val, dict):
                     meta = val.get("metaData", {})
-                    mod_id = meta.get("moduleId")
-                    if mod_id == 255:
+                    module_id = meta.get("moduleId") if isinstance(meta, dict) else None
+                    if module_id is None:
+                        module_id = (
+                            val.get("at", {})
+                            .get("moduleId", {})
+                            .get("value")
+                        )
+                    if module_id == 255 or str(module_id) == "255":
                         continue
                 for module in module_list:
                     if module.lower() in key.lower():
-                        frame[module] = key
+                        instances.setdefault(module, []).append(key)
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.error("Problem parsing module list: %s", err)
             return False
+        for module, keys in instances.items():
+            keys.sort()
+            frame[module] = keys[0]
         self._modules = frame
-        LOGGER.debug("Indexed active modules: %s", list(self._modules.keys()))
+        self._module_instances = instances
+        LOGGER.debug(
+            "Indexed active modules: %s",
+            {module: len(keys) for module, keys in instances.items()},
+        )
         return True
 
-    def get_module(self, module: str) -> int:
+    def get_module(self, module: str, index: int = 0) -> int:
         """Return module port number for device."""
-        if module not in self._modules:
-            LOGGER.warning("Module %s not found in indexed modules", module)
+        keys = self.module_instances(module)
+        if not keys or index < 0 or index >= len(keys):
+            LOGGER.warning(
+                "Module %s instance %s not found in indexed modules", module, index
+            )
             if module in ("garageDoor", "garageLight"):
                 return 7
             return 0
-        val = str(self._modules[module])
+        val = str(keys[index])
         if "_" in val:
             parts = val.split("_")
             for part in parts:
@@ -562,11 +595,16 @@ class RyobiApiClient:
             if module_name == "rssi" and "value" in value_dict:
                 self._data["wifi_rssi"] = value_dict["value"]
         elif "fan" in key:
+            fan_keys = self.module_instances("fan")
+            idx = fan_keys.index(parts[0]) if parts[0] in fan_keys else 0
             if module_name == "speed" and "value" in value_dict:
-                self._data["fan_speed"] = value_dict["value"]
-                self._data["fan"] = 1 if value_dict["value"] > 0 else 0
+                self._data[f"fan_speed_{idx}"] = value_dict["value"]
+                self._data[f"fan_{idx}"] = 1 if value_dict["value"] > 0 else 0
             elif module_name == "moduleState" and "value" in value_dict:
-                self._data["fan"] = value_dict["value"]
+                self._data[f"fan_{idx}"] = value_dict["value"]
+            if idx == 0:
+                self._data["fan_speed"] = self._data.get("fan_speed_0", 0)
+                self._data["fan"] = self._data.get("fan_0", 0)
 
     async def parse_message(self, data: dict) -> None:
         """Parse incoming updated data from WebSocket push."""

--- a/custom_components/ryobi_gdo/binary_sensor.py
+++ b/custom_components/ryobi_gdo/binary_sensor.py
@@ -12,7 +12,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/ryobi_gdo/camera.py
+++ b/custom_components/ryobi_gdo/camera.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.components.camera import Camera
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/ryobi_gdo/const.py
+++ b/custom_components/ryobi_gdo/const.py
@@ -12,6 +12,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
     Platform.COVER,
+    Platform.FAN,
     Platform.SENSOR,
     Platform.SWITCH,
 ]
@@ -41,3 +42,8 @@ SOCK_ERROR = "Error"
 
 # Time in seconds before websocket inactivity triggers reconnect
 WS_INACTIVITY_TIMEOUT = 360
+
+# Fan speed range as (min, max) raw module values. The wall keypad cycles
+# Off -> High -> Medium -> Low, while the module stores an ordinal speed
+# starting at 1.
+FAN_SPEED_RANGE = (1, 3)

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -72,11 +72,13 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return dict(self.client.data)
             raise UpdateFailed(f"Error communicating with Ryobi API: {err}") from err
 
-    async def send_command(self, device: str, command: str, value: Any) -> None:
+    async def send_command(
+        self, device: str, command: str, value: Any, index: int = 0
+    ) -> None:
         """Send command to GDO via WebSocket."""
         try:
             await self._websocket_check()
-            module = self.client.get_module(device)
+            module = self.client.get_module(device, index)
             module_type = self.client.get_module_type(device)
             if self.client.ws is not None and self.client.ws.state == "connected":
                 LOGGER.info(

--- a/custom_components/ryobi_gdo/cover.py
+++ b/custom_components/ryobi_gdo/cover.py
@@ -11,7 +11,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/ryobi_gdo/fan.py
+++ b/custom_components/ryobi_gdo/fan.py
@@ -1,0 +1,165 @@
+"""Ryobi platform for the fan component."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+from . import RyobiConfigEntry
+from .const import DOMAIN, FAN_SPEED_RANGE
+from .coordinator import RyobiDataUpdateCoordinator
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: RyobiConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Ryobi fans, one entity per installed fan module."""
+    coordinator = entry.runtime_data
+    fan_keys = coordinator.client.module_instances("fan")
+
+    if not fan_keys:
+        LOGGER.debug("No fan module present on device %s", coordinator.device_id)
+        return
+
+    multiple = len(fan_keys) > 1
+    async_add_entities(
+        RyobiFan(coordinator, index, multiple) for index in range(len(fan_keys))
+    )
+
+
+class RyobiFan(CoordinatorEntity[RyobiDataUpdateCoordinator], FanEntity):
+    """Representation of a Ryobi accessory fan."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:fan"
+    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_speed_count = int(FAN_SPEED_RANGE[1])
+
+    def __init__(
+        self,
+        coordinator: RyobiDataUpdateCoordinator,
+        index: int,
+        multiple: bool,
+    ) -> None:
+        """Initialize the fan."""
+        super().__init__(coordinator)
+        self.device_id = coordinator.device_id
+        self._index = index
+        # Keep the first fan's unique_id stable so existing installs are not
+        # migrated into a new entity when a second fan appears later.
+        suffix = "fan" if index == 0 else f"fan_{index}"
+        self._attr_unique_id = f"{self.device_id}_{suffix}"
+        self._attr_name = f"Fan {index + 1}" if multiple else "Fan"
+
+    @property
+    def available(self) -> bool:
+        """Return True if the backing fan module is still present."""
+        if self._index >= len(self.coordinator.client.module_instances("fan")):
+            return False
+        return super().available
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device registry information for this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device_id)},
+            manufacturer="Ryobi",
+            model="GDO",
+            name=self.coordinator.data.get(
+                "device_name", f"Ryobi GDO {self.device_id}"
+            ),
+            serial_number=self.device_id,
+        )
+
+    @property
+    def _speed(self) -> int:
+        """Return the raw speed value reported for this fan."""
+        raw = self.coordinator.data.get(f"fan_speed_{self._index}")
+        if raw is None and self._index == 0:
+            raw = self.coordinator.data.get("fan_speed")
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return 0
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the fan is running."""
+        state = self.coordinator.data.get(f"fan_{self._index}")
+        if state is None and self._index == 0:
+            state = self.coordinator.data.get("fan")
+        if state is None:
+            return self._speed > 0
+        return bool(state == 1 or state is True)
+
+    @property
+    def percentage(self) -> int:
+        """Return the current speed as a percentage."""
+        if not self.is_on:
+            return 0
+        return ranged_value_to_percentage(FAN_SPEED_RANGE, self._speed)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the raw module speed so the state is unambiguous."""
+        return {"speed_step": self._speed}
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the fan speed from a percentage."""
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        speed = math.ceil(percentage_to_ranged_value(FAN_SPEED_RANGE, percentage))
+        speed = max(1, min(int(FAN_SPEED_RANGE[1]), speed))
+        LOGGER.debug(
+            "Setting fan %s speed to %s (%s%%) for device %s",
+            self._index,
+            speed,
+            percentage,
+            self.device_id,
+        )
+        await self.coordinator.send_command("fan", "speed", speed, index=self._index)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn the fan on, optionally at a given speed."""
+        if percentage:
+            await self.async_set_percentage(percentage)
+            return
+        await self.coordinator.send_command(
+            "fan", "moduleState", 1, index=self._index
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        LOGGER.debug("Turning off fan %s for device %s", self._index, self.device_id)
+        # Speed 0 is what the keypad sends on the final press of the cycle; the
+        # moduleState write is a belt-and-braces follow-up for firmware that
+        # tracks the two separately.
+        await self.coordinator.send_command("fan", "speed", 0, index=self._index)
+        await self.coordinator.send_command(
+            "fan", "moduleState", 0, index=self._index
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/ryobi_gdo/sensor.py
+++ b/custom_components/ryobi_gdo/sensor.py
@@ -14,7 +14,8 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/ryobi_gdo/switch.py
+++ b/custom_components/ryobi_gdo/switch.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -41,11 +41,6 @@ SWITCH_TYPES: tuple[RyobiSwitchEntityDescription, ...] = (
         icon="mdi:tire",
     ),
     RyobiSwitchEntityDescription(
-        name="Fan",
-        key="fan",
-        icon="mdi:fan",
-    ),
-    RyobiSwitchEntityDescription(
         name="Park Assist Laser",
         key="park_assist",
         icon="mdi:laser-pointer",
@@ -70,7 +65,6 @@ SWITCH_TYPES: tuple[RyobiSwitchEntityDescription, ...] = (
 KEY_TO_MODULE: dict[str, str] = {
     "light_state": "garageLight",
     "inflator": "inflator",
-    "fan": "fan",
     "park_assist": "parkAssistLaser",
     "bt_speaker": "btSpeaker",
     "micStatus": "btSpeaker",
@@ -164,8 +158,6 @@ class RyobiSwitch(CoordinatorEntity[RyobiDataUpdateCoordinator], SwitchEntity):
             await self.coordinator.send_command("btSpeaker", "moduleState", 0)
         elif key == "park_assist":
             await self.coordinator.send_command("parkAssistLaser", "moduleState", 0)
-        elif key == "fan":
-            await self.coordinator.send_command("fan", "moduleState", 0)
         elif key == "inflator":
             await self.coordinator.send_command("inflator", "moduleState", 0)
         else:
@@ -188,8 +180,6 @@ class RyobiSwitch(CoordinatorEntity[RyobiDataUpdateCoordinator], SwitchEntity):
             await self.coordinator.send_command("btSpeaker", "moduleState", 1)
         elif key == "park_assist":
             await self.coordinator.send_command("parkAssistLaser", "moduleState", 1)
-        elif key == "fan":
-            await self.coordinator.send_command("fan", "moduleState", 1)
         elif key == "inflator":
             await self.coordinator.send_command("inflator", "moduleState", 1)
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,118 @@
+"""Test module indexing and fan state handling."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.ryobi_gdo.api import RyobiApiClient
+from custom_components.ryobi_gdo.coordinator import RyobiDataUpdateCoordinator
+
+
+@pytest.fixture
+def client() -> RyobiApiClient:
+    """Return a client for module parsing tests."""
+    return RyobiApiClient(
+        username="TestUser",
+        password="FakePassword",
+        device_id="fakedeviceID02",
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_modules_tracks_fans_and_skips_empty_ports(client):
+    """Index all active fan instances while ignoring empty module ports."""
+    dtm = {
+        "fan_1": {},
+        "fan_0": {},
+        "fan_2": {"at": {"moduleId": {"value": 255}}},
+        "modulePort_4": {"at": {"moduleId": {"value": 255}}},
+    }
+
+    assert await client._index_modules(dtm)
+
+    assert client.modules == {"fan": "fan_0"}
+    assert client.module_instances("fan") == ["fan_0", "fan_1"]
+    assert client.get_module("fan") == 0
+    assert client.get_module("fan", 1) == 1
+    assert client.get_module("fan", 2) == 0
+
+
+@pytest.mark.asyncio
+async def test_parse_accessories_keeps_each_fan_state_separate(client):
+    """Parse speed and state values independently for multiple fans."""
+    await client._index_modules(
+        {
+            "fan_0": {},
+            "fan_1": {},
+        }
+    )
+    dtm = {
+        "fan_0": {
+            "at": {
+                "speed": {"value": 1},
+                "moduleState": {"value": 1},
+            }
+        },
+        "fan_1": {
+            "at": {
+                "speed": {"value": 3},
+                "moduleState": {"value": 1},
+            }
+        },
+    }
+
+    client._parse_accessories(dtm)
+
+    assert client.data["fan_speed_0"] == 1
+    assert client.data["fan_0"] == 1
+    assert client.data["fan_speed_1"] == 3
+    assert client.data["fan_1"] == 1
+    assert client.data["fan_speed"] == 1
+    assert client.data["fan"] == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_message_routes_fan_updates_by_instance(client):
+    """Route WebSocket updates to the fan that generated them."""
+    await client._index_modules(
+        {
+            "fan_0": {},
+            "fan_1": {},
+        }
+    )
+    client._parse_accessories(
+        {
+            "fan_0": {"at": {"speed": {"value": 1}}},
+            "fan_1": {"at": {"speed": {"value": 3}}},
+        }
+    )
+
+    await client.parse_message(
+        {
+            "varName": "fakedeviceID02",
+            "fan_1.speed": {"value": 0},
+        }
+    )
+
+    assert client.data["fan_speed_0"] == 1
+    assert client.data["fan_0"] == 1
+    assert client.data["fan_speed_1"] == 0
+    assert client.data["fan_1"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_command_forwards_module_instance_index():
+    """Send fan commands to the selected module port."""
+    coordinator = object.__new__(RyobiDataUpdateCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.device_id = "fakedeviceID02"
+    coordinator._websocket_check = AsyncMock()
+    coordinator.client.get_module.return_value = 1
+    coordinator.client.get_module_type.return_value = 3
+    coordinator.client.ws.state = "connected"
+    coordinator.client.ws.send_message = AsyncMock()
+
+    await coordinator.send_command("fan", "speed", 2, index=1)
+
+    coordinator.client.get_module.assert_called_once_with("fan", 1)
+    coordinator.client.ws.send_message.assert_awaited_once_with(1, 3, "speed", 2)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,73 @@
+"""Test the Ryobi camera platform."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.ryobi_gdo.camera import RyobiCamera, async_setup_entry
+
+
+class FakeResponse:
+    """Minimal asynchronous camera response."""
+
+    status = 200
+
+    async def read(self) -> bytes:
+        """Return a fake image payload."""
+        return b"fake-jpeg"
+
+
+class FakeRequest:
+    """Minimal asynchronous request context manager."""
+
+    async def __aenter__(self) -> FakeResponse:
+        """Enter the request context."""
+        return FakeResponse()
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        """Exit the request context."""
+
+
+class FakeSession:
+    """Minimal HTTP session for camera image tests."""
+
+    def get(self, url: str, timeout: int) -> FakeRequest:
+        """Return a fake HTTP request."""
+        return FakeRequest()
+
+
+@pytest.fixture
+def coordinator():
+    """Return a coordinator with a camera module."""
+    value = MagicMock()
+    value.device_id = "fakedeviceID02"
+    value.data = {
+        "device_name": "Test GDO",
+        "camera_image_url": "https://camera.example/snapshot.jpg",
+    }
+    value.client.modules = {"camera": "camera_0"}
+    value.client.session = FakeSession()
+    return value
+
+
+@pytest.mark.asyncio
+async def test_camera_setup_adds_camera_entity(coordinator):
+    """Set up one camera entity when a camera module is present."""
+    entities = []
+    entry = SimpleNamespace(runtime_data=coordinator)
+
+    await async_setup_entry(None, entry, entities.extend)
+
+    assert len(entities) == 1
+    assert isinstance(entities[0], RyobiCamera)
+    assert entities[0].unique_id == "fakedeviceID02_security_camera"
+    assert entities[0].device_info["name"] == "Test GDO"
+
+
+@pytest.mark.asyncio
+async def test_camera_image_fetch_returns_image_payload(coordinator):
+    """Fetch and return the camera image bytes."""
+    entity = RyobiCamera(coordinator)
+
+    assert await entity.async_camera_image() == b"fake-jpeg"

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,75 @@
+"""Test the Ryobi fan platform."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.ryobi_gdo.fan import RyobiFan, async_setup_entry
+
+
+@pytest.fixture
+def coordinator():
+    """Return a coordinator with two fan modules."""
+    value = MagicMock()
+    value.device_id = "fakedeviceID02"
+    value.data = {
+        "fan_0": 1,
+        "fan_speed_0": 1,
+        "fan_1": 1,
+        "fan_speed_1": 3,
+    }
+    value.client.module_instances.return_value = ["fan_0", "fan_1"]
+    value.send_command = AsyncMock()
+    value.async_request_refresh = AsyncMock()
+    return value
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_one_named_entity_per_fan(coordinator):
+    """Create one distinct fan entity for every installed module."""
+    entities = []
+    entry = SimpleNamespace(runtime_data=coordinator)
+
+    await async_setup_entry(None, entry, entities.extend)
+
+    assert [entity.unique_id for entity in entities] == [
+        "fakedeviceID02_fan",
+        "fakedeviceID02_fan_1",
+    ]
+    assert [entity.name for entity in entities] == ["Fan 1", "Fan 2"]
+
+
+@pytest.mark.asyncio
+async def test_fan_speed_and_toggle_commands_use_entity_index(coordinator):
+    """Use the selected fan index for speed and toggle commands."""
+    fan = RyobiFan(coordinator, index=1, multiple=True)
+
+    assert fan.is_on is True
+    assert fan.percentage == 100
+
+    await fan.async_set_percentage(50)
+    coordinator.send_command.assert_awaited_once_with(
+        "fan", "speed", 2, index=1
+    )
+
+    coordinator.send_command.reset_mock()
+    await fan.async_turn_on()
+    coordinator.send_command.assert_awaited_once_with(
+        "fan", "moduleState", 1, index=1
+    )
+
+    coordinator.send_command.reset_mock()
+    await fan.async_turn_off()
+    assert coordinator.send_command.await_args_list[0].args == (
+        "fan",
+        "speed",
+        0,
+    )
+    assert coordinator.send_command.await_args_list[0].kwargs == {"index": 1}
+    assert coordinator.send_command.await_args_list[1].args == (
+        "fan",
+        "moduleState",
+        0,
+    )
+    assert coordinator.send_command.await_args_list[1].kwargs == {"index": 1}


### PR DESCRIPTION
## Summary

- Add a native Home Assistant fan platform with per-fan naming, on/off control, and three-step speed control.
- Preserve every active module instance and route fan state updates and commands to the selected port.
- Exclude empty module ports, including the real `modulePort -> at -> moduleId -> value: 255` response shape.
- Remove the competing fan switch and migrate `DeviceInfo` imports across all platforms, including camera.
- Add regression coverage for module indexing, fan routing, camera setup, and camera image retrieval.

## Verification

- 11 pytest tests passed.
- Ruff, Flake8, and Pylint passed.
- Python compilation passed.
- Camera platform import, entity setup, and image retrieval passed.

## Hardware note

Fan hardware is not available for live validation. The raw speed mapping of values 1 through 3 remains based on the documented keypad behavior and should be confirmed with device telemetry before a release tag.

Closes #64
