### PR TITLE
feat: classify battery sensor as diagnostic

### DIFF
--- a/custom_components/ryobi_gdo/sensor.py
+++ b/custom_components/ryobi_gdo/sensor.py
@@ -43,6 +43,7 @@ SENSOR_TYPES: tuple[RyobiSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         required_module="backupCharger",
     ),
     RyobiSensorEntityDescription(

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,6 +4,8 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ryobi_gdo.const import DOMAIN
@@ -39,6 +41,9 @@ async def test_sensors(hass, mock_device, mock_api_key, mock_ws):
     state = hass.states.get("sensor.door2_battery_level")
     assert state
     assert state.state == "0"
+    battery_entity = er.async_get(hass).async_get("sensor.door2_battery_level")
+    assert battery_entity
+    assert battery_entity.entity_category == EntityCategory.DIAGNOSTIC
     state = hass.states.get("sensor.door2_wifi_signal")
     assert state
     assert state.state == "-50"


### PR DESCRIPTION
## Summary

- Classifies the Ryobi Battery Level entity as `diagnostic`.
- Keeps the entity in the sensor domain with the same entity ID and unique ID.
- Adds regression coverage for the entity registry category.

## Test plan

- `pytest -q tests/test_sensors.py::test_sensors`
- `pytest -q` (11 passed)
- Ruff passed
- Flake8 passed
- Pylint passed
- Mypy passed
- Direct Bandit scan found only existing low-severity test-suite findings; the repository pre-commit Bandit hook could not start because its environment is missing `pbr`.

No new release or version change is included in this PR.
